### PR TITLE
Automating package version based on git tags

### DIFF
--- a/autoxtrabackup.py
+++ b/autoxtrabackup.py
@@ -8,10 +8,9 @@ import pid
 import time
 import os
 import humanfriendly
-
+import subprocess
 import logging
 import logging.handlers
-
 logger = logging.getLogger('')
 
 handler = None
@@ -20,12 +19,13 @@ if _platform == "linux" or _platform == "linux2":
     handler = logging.handlers.SysLogHandler(address='/dev/log')
 elif _platform == "darwin":
     # MAC OS X
-    handler = logging.handlers.SysLogHandler(address = '/var/run/syslog')
+    handler = logging.handlers.SysLogHandler(address='/var/run/syslog')
 else:
     handler = logging.handlers.SysLogHandler(address=('localhost',514))
 
 # Set syslog for the root logger
 logger.addHandler(handler)
+version = subprocess.check_output(["git", "describe", "--abbrev=0"]).decode().strip()
 
 def print_version(ctx, param, value):
     if not value or ctx.resilient_parsing:
@@ -34,7 +34,7 @@ def print_version(ctx, param, value):
     click.echo("Link : https://github.com/ShahriyarR/MySQL-AutoXtraBackup")
     click.echo("Email: rzayev.shahriyar@yandex.com")
     click.echo("Based on Percona XtraBackup: https://github.com/percona/percona-xtrabackup/")
-    click.echo('MySQL-AutoXtraBackup Version 1.4.4')
+    click.echo('MySQL-AutoXtraBackup Version: %s' % version)
     ctx.exit()
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,15 @@
 from setuptools import setup
+from autoxtrabackup import version
 
 datafiles = [('//etc', ['general_conf/bck.conf'])]
 
 setup(
     name='mysql-autoxtrabackup',
-    version='1.4.4',
+    version=version,
     packages=['general_conf', 'backup_prepare', 'partial_recovery', 'master_backup_script'],
     py_modules = ['autoxtrabackup'],
     url='https://github.com/ShahriyarR/MySQL-AutoXtraBackup',
-    download_url = 'https://github.com/ShahriyarR/MySQL-AutoXtraBackup/tarball/v1.4.3',
+    download_url = 'https://github.com/ShahriyarR/MySQL-AutoXtraBackup/tarball/%s' % version,
     license='MIT',
     author='Shahriyar Rzayev',
     author_email='rzayev.shahriyar@yandex.com',


### PR DESCRIPTION
I've noticed that every time you change the version i.e. git tag, you go change. Example: https://github.com/ShahriyarR/MySQL-AutoXtraBackup/commit/e20587df855faa09f3d0c03d65d17339c40ab419

When we roll out a new version, we can add a new git tag and make software itself figure out which version it's using. 

`git describe --abbrev=0` is the command that we want to get the latest tag. In this PR, we're utilizing it.

To test it, I added a new tag on this feature branch on my local and here's the output of
```
$ sudo python3 setup.py install
```
```
/usr/local/lib/python3.6/site-packages/setuptools/dist.py:332: UserWarning: Normalizing 'v1.4.5' to '1.4.5'
  normalized_version,
running install
running bdist_egg
running egg_info
writing mysql_autoxtrabackup.egg-info/PKG-INFO
writing dependency_links to mysql_autoxtrabackup.egg-info/dependency_links.txt
writing entry points to mysql_autoxtrabackup.egg-info/entry_points.txt
writing requirements to mysql_autoxtrabackup.egg-info/requires.txt
writing top-level names to mysql_autoxtrabackup.egg-info/top_level.txt
reading manifest file 'mysql_autoxtrabackup.egg-info/SOURCES.txt'
writing manifest file 'mysql_autoxtrabackup.egg-info/SOURCES.txt'
installing library code to build/bdist.macosx-10.11-x86_64/egg
running install_lib
running build_py
copying autoxtrabackup.py -> build/lib
creating build/bdist.macosx-10.11-x86_64/egg
copying build/lib/autoxtrabackup.py -> build/bdist.macosx-10.11-x86_64/egg
creating build/bdist.macosx-10.11-x86_64/egg/backup_prepare
copying build/lib/backup_prepare/__init__.py -> build/bdist.macosx-10.11-x86_64/egg/backup_prepare
copying build/lib/backup_prepare/prepare.py -> build/bdist.macosx-10.11-x86_64/egg/backup_prepare
creating build/bdist.macosx-10.11-x86_64/egg/general_conf
copying build/lib/general_conf/__init__.py -> build/bdist.macosx-10.11-x86_64/egg/general_conf
copying build/lib/general_conf/check_env.py -> build/bdist.macosx-10.11-x86_64/egg/general_conf
copying build/lib/general_conf/generalops.py -> build/bdist.macosx-10.11-x86_64/egg/general_conf
creating build/bdist.macosx-10.11-x86_64/egg/master_backup_script
copying build/lib/master_backup_script/__init__.py -> build/bdist.macosx-10.11-x86_64/egg/master_backup_script
copying build/lib/master_backup_script/backuper.py -> build/bdist.macosx-10.11-x86_64/egg/master_backup_script
copying build/lib/master_backup_script/check_env.py -> build/bdist.macosx-10.11-x86_64/egg/master_backup_script
creating build/bdist.macosx-10.11-x86_64/egg/partial_recovery
copying build/lib/partial_recovery/__init__.py -> build/bdist.macosx-10.11-x86_64/egg/partial_recovery
copying build/lib/partial_recovery/partial.py -> build/bdist.macosx-10.11-x86_64/egg/partial_recovery
byte-compiling build/bdist.macosx-10.11-x86_64/egg/autoxtrabackup.py to autoxtrabackup.cpython-36.pyc
byte-compiling build/bdist.macosx-10.11-x86_64/egg/backup_prepare/__init__.py to __init__.cpython-36.pyc
byte-compiling build/bdist.macosx-10.11-x86_64/egg/backup_prepare/prepare.py to prepare.cpython-36.pyc
byte-compiling build/bdist.macosx-10.11-x86_64/egg/general_conf/__init__.py to __init__.cpython-36.pyc
byte-compiling build/bdist.macosx-10.11-x86_64/egg/general_conf/check_env.py to check_env.cpython-36.pyc
byte-compiling build/bdist.macosx-10.11-x86_64/egg/general_conf/generalops.py to generalops.cpython-36.pyc
byte-compiling build/bdist.macosx-10.11-x86_64/egg/master_backup_script/__init__.py to __init__.cpython-36.pyc
byte-compiling build/bdist.macosx-10.11-x86_64/egg/master_backup_script/backuper.py to backuper.cpython-36.pyc
byte-compiling build/bdist.macosx-10.11-x86_64/egg/master_backup_script/check_env.py to check_env.cpython-36.pyc
byte-compiling build/bdist.macosx-10.11-x86_64/egg/partial_recovery/__init__.py to __init__.cpython-36.pyc
byte-compiling build/bdist.macosx-10.11-x86_64/egg/partial_recovery/partial.py to partial.cpython-36.pyc
installing package data to build/bdist.macosx-10.11-x86_64/egg
running install_data
creating build/bdist.macosx-10.11-x86_64/egg/EGG-INFO
copying mysql_autoxtrabackup.egg-info/PKG-INFO -> build/bdist.macosx-10.11-x86_64/egg/EGG-INFO
copying mysql_autoxtrabackup.egg-info/SOURCES.txt -> build/bdist.macosx-10.11-x86_64/egg/EGG-INFO
copying mysql_autoxtrabackup.egg-info/dependency_links.txt -> build/bdist.macosx-10.11-x86_64/egg/EGG-INFO
copying mysql_autoxtrabackup.egg-info/entry_points.txt -> build/bdist.macosx-10.11-x86_64/egg/EGG-INFO
copying mysql_autoxtrabackup.egg-info/requires.txt -> build/bdist.macosx-10.11-x86_64/egg/EGG-INFO
copying mysql_autoxtrabackup.egg-info/top_level.txt -> build/bdist.macosx-10.11-x86_64/egg/EGG-INFO
zip_safe flag not set; analyzing archive contents...
creating 'dist/mysql_autoxtrabackup-1.4.5-py3.6.egg' and adding 'build/bdist.macosx-10.11-x86_64/egg' to it
removing 'build/bdist.macosx-10.11-x86_64/egg' (and everything under it)
Processing mysql_autoxtrabackup-1.4.5-py3.6.egg
Copying mysql_autoxtrabackup-1.4.5-py3.6.egg to /usr/local/lib/python3.6/site-packages
Removing mysql-autoxtrabackup 1.4.4 from easy-install.pth file
Adding mysql-autoxtrabackup 1.4.5 to easy-install.pth file
Installing autoxtrabackup script to /usr/local/bin

Installed /usr/local/lib/python3.6/site-packages/mysql_autoxtrabackup-1.4.5-py3.6.egg
Processing dependencies for mysql-autoxtrabackup==1.4.5
Searching for humanfriendly==2.3.2
Best match: humanfriendly 2.3.2
Processing humanfriendly-2.3.2-py3.6.egg
humanfriendly 2.3.2 is already the active version in easy-install.pth
Installing humanfriendly script to /usr/local/bin

Using /usr/local/lib/python3.6/site-packages/humanfriendly-2.3.2-py3.6.egg
Searching for pid==2.1.1
Best match: pid 2.1.1
Processing pid-2.1.1-py3.6.egg
pid 2.1.1 is already the active version in easy-install.pth

Using /usr/local/lib/python3.6/site-packages/pid-2.1.1-py3.6.egg
Searching for mysql-connector==2.1.4
Best match: mysql-connector 2.1.4
Processing mysql_connector-2.1.4-py3.6-macosx-10.11-x86_64.egg
mysql-connector 2.1.4 is already the active version in easy-install.pth

Using /usr/local/lib/python3.6/site-packages/mysql_connector-2.1.4-py3.6-macosx-10.11-x86_64.egg
Searching for click==6.7
Best match: click 6.7
Processing click-6.7-py3.6.egg
click 6.7 is already the active version in easy-install.pth

Using /usr/local/lib/python3.6/site-packages/click-6.7-py3.6.egg
Finished processing dependencies for mysql-autoxtrabackup==1.4.5
``` 

And this:
```
$ /usr/local/bin/autoxtrabackup --version
```
```
Developed by Shahriyar Rzayev from Azerbaijan MUG(http://mysql.az)
Link : https://github.com/ShahriyarR/MySQL-AutoXtraBackup
Email: rzayev.shahriyar@yandex.com
Based on Percona XtraBackup: https://github.com/percona/percona-xtrabackup/
MySQL-AutoXtraBackup Version: v1.4.5
```
 