### PR TITLE
undefined max_archive_size in bck.conf leads to AttributeError

### DIFF
--- a/master_backup_script/backuper.py
+++ b/master_backup_script/backuper.py
@@ -261,7 +261,7 @@ class Backup(GeneralClass):
             # Finding if last full backup older than the interval or more from
             # now!
 
-            if (now - archive_date).total_seconds() >= self.max_archive_duration:
+            if hasattr(self, 'max_archive_duration') and (now - archive_date).total_seconds() >= self.max_archive_duration:
                 logger.debug(
                     "Removing archive: " +
                     self.archive_dir +
@@ -272,7 +272,7 @@ class Backup(GeneralClass):
                     shutil.rmtree(self.archive_dir + "/" + archive)
                 else:
                     os.remove(self.archive_dir + "/" + archive)
-            elif self.get_directory_size(self.archive_dir) > self.max_archive_size:
+            elif hasattr(self, 'max_archive_size') and self.get_directory_size(self.archive_dir) > self.max_archive_size:
                 logger.debug(
                     "Removing archive: " +
                     self.archive_dir +


### PR DESCRIPTION
When either max_archive_size or max_archive_duration remains unset this leads to 

```
File "/usr/local/lib/python3.4/dist-packages/mysql_autoxtrabackup-1.5.2-py3.4.egg/master_backup_script/backuper.py", line 278, in clean_old_archives
    elif self.get_directory_size(self.archive_dir) > self.max_archive_size:
AttributeError: 'Backup' object has no attribute 'max_archive_size'
```

I prefer to only set the number of rotations as the total size is unknown / doesn't matter to me. 1 or 2 weeks worth of backups is better than '100GB' or something alike. This way both can still be set and used but it doesn't break on not-setting the size.
I could also think of another fix; setting the size to 0 (zero). But this should be documented and is probably a less intuitive way of achieving the same.

Let me know what you think about this! 