### PR TITLE
Mask password in debug logs

### DIFF
--- a/general_conf/check_env.py
+++ b/general_conf/check_env.py
@@ -1,5 +1,5 @@
 #!/opt/Python-3.3.2/bin/python3
-
+import re
 import shlex
 import subprocess
 import os
@@ -43,8 +43,12 @@ class CheckEnv(GeneralClass):
                 raise RuntimeError("Neither mysql_socket nor mysql_host and mysql_port are defined in config!")
         else:
             statusargs = "{} {} status".format(self.mysqladmin, options)
-        
-        logger.debug("Running mysqladmin command -> {}".format(statusargs))
+
+        # filter out password from argument list
+        filteredargs = re.sub("--password='?\w+'?", "--password='*'", statusargs)
+
+        logger.debug("Running mysqladmin command -> {}".format(filteredargs))
+
         #statusargs = shlex.split(statusargs)
         status, output = subprocess.getstatusoutput(statusargs)
         #myadmin = subprocess.Popen(statusargs, stdout=subprocess.PIPE)

--- a/master_backup_script/backuper.py
+++ b/master_backup_script/backuper.py
@@ -5,6 +5,7 @@
 
 
 import os
+import re
 import subprocess
 import shlex
 import shutil
@@ -388,7 +389,10 @@ class Backup(GeneralClass):
             args += " > {}/full_backup.tar".format(full_backup_dir)
             logger.warning("Streaming tar is enabled!")
 
-        logger.debug("The following backup command will be executed {}".format(args))
+        # filter out password from argument list
+        filteredargs = re.sub("--password='?\w+'?", "--password='*'", args)
+
+        logger.debug("The following backup command will be executed {}".format(filteredargs))
 
         if self.dry == 0:
             logger.debug("Starting {}".format(self.backup_tool))
@@ -607,7 +611,11 @@ class Backup(GeneralClass):
                 raise RuntimeError("xtrabackup: error: streaming incremental backups are incompatible with the "
                                    "'tar' streaming format. Use --stream=xbstream instead.")
 
-            logger.debug("The following backup command will be executed {}".format(args))
+            # filter out password from argument list
+            filteredargs = re.sub("--password='?\w+'?", "--password='*'", args)
+
+            logger.debug("The following backup command will be executed {}".format(filteredargs))
+
             if self.dry == 0:
                 status, output = subprocess.getstatusoutput(args)
                 if status == 0:
@@ -783,7 +791,10 @@ class Backup(GeneralClass):
                 args += " > {}/inc_backup.stream".format(inc_backup_dir)
                 logger.warning("Streaming is enabled!")
 
-            logger.debug("The following backup command will be executed {}".format(args))
+            # filter out password from argument list
+                filteredargs = re.sub("--password='?\w+'?", "--password='*'", args)
+
+            logger.debug("The following backup command will be executed {}".format(filteredargs))
 
             if self.dry == 0:
                 status, output = subprocess.getstatusoutput(args)


### PR DESCRIPTION
Fix for issue #285 

Mask by regular-expression replacing the password part in the connection string. Copies the string in order not to mess up the actual (re)connection. 

Matches on '--password= with optional quotes around a word. So both `--password=asdf` and `--password='asdf'` are matching. 

