### PR TITLE
Update doc

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -19,6 +19,20 @@ Installing dependencies:
 
     yum install openssl openssl-devel zlib zlib-devel
 
+On Debian/Ubuntu
+::
+
+    apt-get install openssl libssl-dev zlib1g zlib1g-dev
+
+(Optional) for multicore zipping install pigz
+::
+
+    yum install pigz
+
+::
+
+    apt-get install pigz
+
 Installing latest XtraBackup:
 For more options please refer to official documentation -> `Installing Percona XtraBackup 2.4 <https://www.percona.com/doc/percona-xtrabackup/2.4/installation.html>`_
 

--- a/docs/option_reference.rst
+++ b/docs/option_reference.rst
@@ -92,12 +92,24 @@ log_file, lf
 -lf, --log_file
 Pass, the path for log file, for autoxtrabackup. Default is ``/var/log/autoxtrabackup.log``
 
+log_file_backup_count
+------------
+
+--log_file_backup_count
+Set log file backup count. Default is 7
+
+log_file_max_bytes
+------------
+
+--log_file_max_bytes
+Set log file max size in bytes. Default: 1073741824 bytes.
+
 log
 ----
 
 -l, --log
 
-Set the log level for tool.
+Set the log level for tool. Can be DEBUG, INFO, WARNING, ERROR or CRITICAL. Default is WARNING.
 
 test_mode
 ---------

--- a/docs/option_reference.rst
+++ b/docs/option_reference.rst
@@ -93,13 +93,13 @@ log_file, lf
 Pass, the path for log file, for autoxtrabackup. Default is ``/var/log/autoxtrabackup.log``
 
 log_file_backup_count
-------------
+---------------------
 
 --log_file_backup_count
 Set log file backup count. Default is 7
 
 log_file_max_bytes
-------------
+------------------
 
 --log_file_max_bytes
 Set log file max size in bytes. Default: 1073741824 bytes.


### PR DESCRIPTION
- Added ubuntu/debian example for the prereqs. The difference is foremost in the packages names (zlib and openssl-devel are named differently).

- Added the log file max count + max size to the option reference.