### PR TITLE
Bugfix issue345

### DIFF
--- a/general_conf/generalops.py
+++ b/general_conf/generalops.py
@@ -69,12 +69,16 @@ class GeneralClass:
                 self.prepare_archive = BCK['prepare_archive']
             if 'move_archive' in BCK:
                 self.move_archive = BCK['move_archive']
+            # backward compatible with old config 'max_archive_size' and newer 'archive_max_size'
             if 'max_archive_size' in BCK:
-                self.max_archive_size = humanfriendly.parse_size(
-                    BCK['archive_max_size'])
+                self.archive_max_size = humanfriendly.parse_size(BCK['max_archive_size'])
+            elif 'archive_max_size' in BCK:
+                self.archive_max_size = humanfriendly.parse_size(BCK['archive_max_size'])
+            # backward compatible with old config 'max_archive_duration' and newer 'archive_max_duration'
             if 'max_archive_duration' in BCK:
-                self.max_archive_duration = humanfriendly.parse_timespan(
-                    BCK['archive_max_duration'])
+                self.archive_max_duration = humanfriendly.parse_timespan(BCK['max_archive_duration'])
+            elif 'archive_max_duration' in BCK:
+                self.archive_max_duration = humanfriendly.parse_timespan(BCK['archive_max_duration'])
             if 'partial_list' in BCK:
                 self.partial_list = BCK['partial_list']
 

--- a/master_backup_script/backuper.py
+++ b/master_backup_script/backuper.py
@@ -280,25 +280,15 @@ class Backup(GeneralClass):
 
             # Finding if last full backup older than the interval or more from
             # now!
-
-            if hasattr(self, 'max_archive_duration') and (now - archive_date).total_seconds() >= self.max_archive_duration:
-                logger.debug(
-                    "Removing archive: " +
-                    self.archive_dir +
-                    "/" +
-                    archive +
-                    " due to max archive age")
+            cleanup_msg = "Removing archive {}/{} due to {}"
+            if hasattr(self, 'archive_max_duration') and (now - archive_date).total_seconds() >= self.archive_max_duration:
+                logger.debug(cleanup_msg.format(self.archive_dir, archive, 'archive_max_duration exceeded.'))
                 if os.path.isdir(self.archive_dir + "/" + archive):
                     shutil.rmtree(self.archive_dir + "/" + archive)
                 else:
                     os.remove(self.archive_dir + "/" + archive)
-            elif hasattr(self, 'max_archive_size') and self.get_directory_size(self.archive_dir) > self.max_archive_size:
-                logger.debug(
-                    "Removing archive: " +
-                    self.archive_dir +
-                    "/" +
-                    archive +
-                    " due to max archive size")
+            elif hasattr(self, 'archive_max_size') and self.get_directory_size(self.archive_dir) > self.archive_max_size:
+                logger.debug(cleanup_msg.format(self.archive_dir, archive, 'archive_max_size exceeded.'))
                 if os.path.isdir(self.archive_dir + "/" + archive):
                     shutil.rmtree(self.archive_dir + "/" + archive)
                 else:
@@ -795,8 +785,9 @@ class Backup(GeneralClass):
 
                 # Archiving backups
                 if hasattr(self, 'archive_dir'):
-                    if (hasattr(self, 'max_archive_duration') and self.max_archive_duration) \
-                            or (hasattr(self, 'max_archive_size') and self.max_archive_size):
+                    logger.debug("Archiving enabled; cleaning archive_dir & archiving previous Full Backup")
+                    if (hasattr(self, 'archive_max_duration') and self.archive_max_duration) \
+                            or (hasattr(self, 'archive_max_size') and self.archive_max_size):
                         self.clean_old_archives()
                     self.create_backup_archives()
                 else:

--- a/prepare_env_test_mode/config_generator.py
+++ b/prepare_env_test_mode/config_generator.py
@@ -109,8 +109,8 @@ class ConfigGenerator(CloneBuildStartServer):
                 config.set(section2, "#prepare_archive", "1")
                 config.set(section2, "#move_archive", "0")
                 config.set(section2, "#full_backup_interval", "1 day")
-                config.set(section2, "#max_archive_size", "100GiB")
-                config.set(section2, "#max_archive_duration", "4 Days")
+                config.set(section2, "#archive_max_size", "100GiB")
+                config.set(section2, "#archive_max_duration", "4 Days")
                 config.set(section2, "#Optional: WARNING(Enable this if you want to take partial backups). "
                                      "Specify database names or table names.")
                 config.set(section2, "#partial_list", "test.t1 test.t2 dbtest")


### PR DESCRIPTION
Main component to this fix is generalops.py was checking for max_archive_size in BCK, but then trying to assign archive_max_size (instead of what it checked for: max_archive_size). So, the variables were never being set properly.

archive_max_[size/duration] seems like the preferred variable names so I cleaned that up a bit throughout the project.

closes 345