### PR TITLE
Fix some errors

### DIFF
--- a/general_conf/check_env.py
+++ b/general_conf/check_env.py
@@ -27,7 +27,7 @@ class CheckEnv(GeneralClass):
         '''
         if options is None:
 
-            statusargs = '{} --defaults-file={} --user={} --password={} status'.format(self.mysqladmin,
+            statusargs = "{} --defaults-file={} --user={} --password='{}' status".format(self.mysqladmin,
                                                                                    self.mycnf,
                                                                                    self.mysql_user,
                                                                                    self.mysql_password)

--- a/master_backup_script/backuper.py
+++ b/master_backup_script/backuper.py
@@ -176,10 +176,10 @@ class Backup(GeneralClass):
         :raise: RuntimError on error.
         """
         if hasattr(self, 'mysql_socket'):
-            command_connection = '{} --defaults-file={} -u{} --password={}'
+            command_connection = "{} --defaults-file={} -u{} --password='{}' "
             command_execute = ' -e "flush logs"'
         else:
-            command_connection = '{} --defaults-file={} -u{} --password={} --host={}'
+            command_connection = "{} --defaults-file={} -u{} --password='{}' --host={}"
             command_execute = ' -e "flush logs"'
 
         # Open connection

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     description='Commandline tool written in Python 3 for using Percona XtraBackup',
     install_requires=[
         'click>=3.3',
-        'mysql-connector==2.1.4',
+        'mysql-connector-python==2.1.4',
         'pid>=2.0',
         'humanfriendly>=2.0',
         'pytest'


### PR DESCRIPTION
There is no python mysql-connector package anymore, it's now called mysql-connector-python.
Password should always be used with quotation marks.