### PR TITLE
feature: add new option for generate default config file in default path

### DIFF
--- a/mysql_autoxtrabackup/general_conf/generalops.py
+++ b/mysql_autoxtrabackup/general_conf/generalops.py
@@ -95,11 +95,10 @@ class GeneralClass:
         archive_max_size = self.con.get(section, "max_archive_size", fallback=None)
         if archive_max_size:
             archive_max_size = humanfriendly.parse_size(archive_max_size)
-        else:
-            if self.con.get(section, "archive_max_size", fallback=None):
-                archive_max_size = humanfriendly.parse_size(
-                    self.con.get(section, "archive_max_size", fallback=None)
-                )
+        elif self.con.get(section, "archive_max_size", fallback=None):
+            archive_max_size = humanfriendly.parse_size(
+                self.con.get(section, "archive_max_size", fallback=None)
+            )
 
         # backward compatible with old config 'max_archive_duration' and newer 'archive_max_duration'
         archive_max_duration = self.con.get(
@@ -107,11 +106,10 @@ class GeneralClass:
         )
         if archive_max_duration:
             archive_max_duration = humanfriendly.parse_timespan(archive_max_duration)
-        else:
-            if self.con.get(section, "archive_max_size", fallback=None):
-                archive_max_duration = humanfriendly.parse_timespan(
-                    self.con.get(section, "archive_max_size", fallback=None)
-                )
+        elif self.con.get(section, "archive_max_size", fallback=None):
+            archive_max_duration = humanfriendly.parse_timespan(
+                self.con.get(section, "archive_max_size", fallback=None)
+            )
 
         return {
             "archive_dir": self.con.get(section, "archive_dir", fallback=None),  # type: ignore


### PR DESCRIPTION
As discussed in #446 it can be valuable to add an commandline option to generate the default config file is this was somehow eliminated by setup.

--generate-config-file flag option was added. Sample run will be something like this:
autoxtrabackup --generate-config-file --verbose
2021-10-03 19:03:07 INFO [autoxtrabackup:278] Default config file is generated in /home/shako/.autoxtrabackup/autoxtrabackup.cnf
2021-10-03 19:03:07 INFO [autoxtrabackup:313] Xtrabackup command history:
2021-10-03 19:03:07 INFO [autoxtrabackup:315] ['command', 'xtrabackup_function', 'start time', 'end time', 'duration', 'exit code']
2021-10-03 19:03:07 INFO [autoxtrabackup:316] Autoxtrabackup completed successfully!

Closes #446 