### PR TITLE
bugfix: ValueError: could not convert string to float: 'None'

### DIFF
--- a/mysql_autoxtrabackup/autoxtrabackup.py
+++ b/mysql_autoxtrabackup/autoxtrabackup.py
@@ -17,7 +17,9 @@ from mysql_autoxtrabackup.backup_backup.backuper import Backup
 from mysql_autoxtrabackup.backup_prepare.prepare import Prepare
 from mysql_autoxtrabackup.general_conf import path_config
 from mysql_autoxtrabackup.general_conf.generalops import GeneralClass
-from mysql_autoxtrabackup.general_conf.generate_default_conf import GenerateDefaultConfig
+from mysql_autoxtrabackup.general_conf.generate_default_conf import (
+    GenerateDefaultConfig,
+)
 from mysql_autoxtrabackup.process_runner.process_runner import ProcessRunner
 from mysql_autoxtrabackup.utils import version
 
@@ -137,7 +139,7 @@ def validate_file(file: str) -> Optional[bool]:
     "--generate-config-file",
     is_flag=True,
     is_eager=True,
-    help="Create a config file template in default directory"
+    help="Create a config file template in default directory",
 )
 @click.option("--tag", help="Pass the tag string for each backup")
 @click.option("--show-tags", is_flag=True, help="Show backup tags and exit")

--- a/mysql_autoxtrabackup/backup_backup/backup_archive.py
+++ b/mysql_autoxtrabackup/backup_backup/backup_archive.py
@@ -7,6 +7,7 @@ from typing import Union
 from mysql_autoxtrabackup.backup_backup.backup_builder import BackupBuilderChecker
 from mysql_autoxtrabackup.general_conf import path_config
 from mysql_autoxtrabackup.general_conf.generalops import GeneralClass
+from mysql_autoxtrabackup.process_runner.errors import BackupArchiveNotConfigured
 from mysql_autoxtrabackup.process_runner.process_runner import ProcessRunner
 from mysql_autoxtrabackup.utils import helpers
 
@@ -126,6 +127,14 @@ class BackupArchive:
         archive_dir = str(self.backup_archive_options.get("archive_dir"))
         # Finding if last full backup older than the interval or more from now!
         cleanup_msg = "Removing archive {}/{} due to {}"
+        if not self.backup_archive_options.get(
+            "archive_max_duration", None
+        ) and not self.backup_archive_options.get("archive_max_size", None):
+            raise BackupArchiveNotConfigured(
+                expression="BackupArchiveNotConfigured",
+                message="You need to both set archive_max_size and archive_max_duration in config file.",
+            )
+
         for archive in helpers.sorted_ls(archive_dir):
             if "_archive" in archive:
                 archive_date = datetime.strptime(archive, "%Y-%m-%d_%H-%M-%S_archive")

--- a/mysql_autoxtrabackup/general_conf/generalops.py
+++ b/mysql_autoxtrabackup/general_conf/generalops.py
@@ -106,9 +106,9 @@ class GeneralClass:
         )
         if archive_max_duration:
             archive_max_duration = humanfriendly.parse_timespan(archive_max_duration)
-        elif self.con.get(section, "archive_max_size", fallback=None):
+        elif self.con.get(section, "archive_max_duration", fallback=None):
             archive_max_duration = humanfriendly.parse_timespan(
-                self.con.get(section, "archive_max_size", fallback=None)
+                self.con.get(section, "archive_max_duration", fallback=None)
             )
 
         return {

--- a/mysql_autoxtrabackup/process_runner/errors.py
+++ b/mysql_autoxtrabackup/process_runner/errors.py
@@ -55,3 +55,14 @@ class SomethingWentWrong(Error):
         self.expression = expression
         self.message = message
         log_error(self.expression, self.message)
+
+
+class BackupArchiveNotConfigured(Error):
+    """
+    Exception raised when archive_max_size and archive_max_duration configs are not set
+    """
+
+    def __init__(self, expression: str, message: str) -> None:
+        self.expression = expression
+        self.message = message
+        log_error(self.expression, self.message)


### PR DESCRIPTION
The wrong config option was used and it fails when the tool tries to use backup archive feature.

Now it will raise BackupArchiveNotConfigured error if options were not set and also it will check for archive_max_duration