### PR TITLE
Update generalops.py

### DIFF
--- a/mysql_autoxtrabackup/general_conf/generalops.py
+++ b/mysql_autoxtrabackup/general_conf/generalops.py
@@ -108,9 +108,9 @@ class GeneralClass:
         if archive_max_duration:
             archive_max_duration = humanfriendly.parse_timespan(archive_max_duration)
         else:
-            if self.con.get(section, "archive_max_size", fallback=None):
+            if self.con.get(section, "archive_max_duration", fallback=None):
                 archive_max_duration = humanfriendly.parse_timespan(
-                    self.con.get(section, "archive_max_size", fallback=None)
+                    self.con.get(section, "archive_max_duration", fallback=None)
                 )
 
         return {


### PR DESCRIPTION
fix bug:
  File "/usr/local/lib/python3.6/dist-packages/mysql_autoxtrabackup/backup_backup/backup_archive.py", line 142, in clean_old_archives
    >= float(str(self.backup_archive_options.get("archive_max_duration")))
ValueError: could not convert string to float: 'None'